### PR TITLE
Don't require implementing the selfTest and logData methods to be implemented

### DIFF
--- a/src/main/java/frc/subsytem/AbstractSubsystem.java
+++ b/src/main/java/frc/subsytem/AbstractSubsystem.java
@@ -34,9 +34,9 @@ public abstract class AbstractSubsystem implements Runnable {
         this(period, Constants.DEFAULT_PERIODS_PER_LOG);
     }
 
-    public abstract void selfTest();
+    public void selfTest() {}
 
-    public abstract void logData();
+    public void logData() {}
 
     public void logData(@NotNull String key, @NotNull Object value) {
         loggingTable.getEntry(key).setValue(value);


### PR DESCRIPTION
Some subsystems won't use them and it doesn't make sense to require that they be implemented