### PR TITLE
Check flatness of the robot before auto grabbing at the double substation

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -33,6 +33,8 @@ public final class Constants {
             100000000 : // 100 MB
             1000000000; // 1 GB
 
+    public static final double GYRO_IS_FLAT_FOR_PICKUP_THRESHOLD_DEGREES = 2;
+
     // Drive Constants
     public static final double SWERVE_MOTOR_POSITION_CONVERSION_FACTOR = 1 / 12.8;
     public static final int DEFAULT_PERIODS_PER_LOG = 0;


### PR DESCRIPTION
- Move auto grab code into a different block of code instead of having it be part of the normal grabber controls
- Always disable auto grab whenever we go to stow & disable it whenever we toggle to grabber closed using the controls. This should hopefully resolve all the instances where the grabber would sometimes not close properly 
- Checks flatness of the robot when doing a double substation pickup